### PR TITLE
Fix splicing error in esxml-listify

### DIFF
--- a/esxml.el
+++ b/esxml.el
@@ -262,8 +262,8 @@ instead creates an ordered list.  If ITEM-ATTRS is non-nil it
 specifies attributes to apply to each item.  ITEM-ATTRS must be
 an alist satisfying `attrsp'."
   `(,(if ordered-p 'ol 'ul) ()
-    ,@(kvmap-bind body
-          `(li () ,@body)
+    ,@(kvmap-bind item
+          `(li () ,item)
         body)))
 
 (defun esxml-create-bookmark-list (bookmark-list seperator &optional ordered-p)


### PR DESCRIPTION
Example text case:

``` elisp
(esxml-listify '((a ((href . "/path/to/somewhere")) "blah")))
```

evaluates to

``` elisp
(ul nil
    (li nil a
        ((href . "/path/to/somewhere"))
        "blah"))
```

instead of

``` elisp
(ul nil
    (li nil (a
             ((href . "/path/to/somewhere"))
             "blah")))
```

so it was splicing each element of the input list.
