### PR TITLE
Always require cl in esxml.el

### DIFF
--- a/esxml.el
+++ b/esxml.el
@@ -44,8 +44,7 @@
 ;; resolve these issues.
 ;;
 ;;; Code:
-(eval-when-compile
-  (require 'cl))
+(require 'cl)
 (require 'xml)
 (require 'pcase)
 


### PR DESCRIPTION
esxml.el uses every, which is a function and not a macro. 
This means cl is required not only when compiling.