### PR TITLE
Entity encode body and attribute strings

### DIFF
--- a/esxml.el
+++ b/esxml.el
@@ -81,7 +81,7 @@ general use."
     (cl-check-type cdr string)
     (concat (symbol-name car)
             "="
-            (prin1-to-string cdr))))
+            (prin1-to-string (xml-escape-string cdr)))))
 
 (defun attrsp (attrs)
     "Returns t if attrs is a list of esxml attributes.
@@ -120,7 +120,7 @@ it suitable for hindsight testing."
 (defun esxml--to-xml-recursive (esxml)
   (pcase esxml
     ((pred stringp)
-     esxml)
+     (xml-escape-string esxml))
     (`(comment nil ,body)
      (concat "<!--" body "-->"))
     (`(,tag ,attrs . ,body)
@@ -166,11 +166,11 @@ STRING: if the esxml expression is a string it is returned
 
 (defun pp-esxml-to-xml (esxml)
   "This translates an esxml expresion as `esxml-to-xml' but
-indents it for ease of human readability, it is neccesarrily
+indents it for ease of human readability, it is necessarily
 slower and will produce longer output."
   (pcase esxml
     ((pred stringp)
-     esxml)
+     (xml-escape-string esxml))
     (`(comment nil ,body)
      (concat "<!--" body "-->"))
     (`(,tag ,attrs . ,body)


### PR DESCRIPTION
```elisp
(require 'esxml)

(esxml-to-xml
 '(foo ((bar . "baz")) (qux "q<b>bold</b>uux")))
;; before: "<foo bar=\"baz\"><qux>q<b>bold</b>uux</qux></foo>"
;; after: "<foo bar=\"baz\"><qux>q&lt;b&gt;bold&lt;/b&gt;uux</qux></foo>"

(esxml-to-xml
 '(foo ((bar . "baz")) (q><b>bold</b><ux "quux")))
;; => "<foo bar=\"baz\"><q><b>bold</b><ux>quux</q><b>bold</b><ux></foo>"

(esxml-to-xml
 '(foo ((bar . "b<b>bold</b>az")) (qux "quux")))
;; before: "<foo bar=\"b<b>bold</b>az\"><qux>quux</qux></foo>"
;; after: "<foo bar=\"b&lt;b&gt;bold&lt;/b&gt;az\"><qux>quux</qux></foo>"

(esxml-to-xml
 '(foo ((b><b>bold</b><ar . "baz")) (qux "quux")))
;; => "<foo b><b>bold</b><ar=\"baz\"><qux>quux</qux></foo>"
```

This PR doesn't fix the the cases where an invalid tag/attribut name or comment body is interpolated. As per https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html it doesn't make sense to use entity encoding there. Accepting user input in these positions pretty much spells disaster. Same goes for `style` and `script` tags and attributes containing JavaScript.