### PR TITLE
Remove duplicate `raw-string` handling

### DIFF
--- a/esxml.el
+++ b/esxml.el
@@ -218,12 +218,8 @@ slower and will produce longer output."
 
 (defun sxml-to-esxml (sxml)
   "Translates sxml to esxml so the common standard can be used.
-See: http://okmij.org/ftp/Scheme/SXML.html. Additionally,
-(*RAW-STRING* \"string\") is translated to (raw-string
-\"string\")."
+See: http://okmij.org/ftp/Scheme/SXML.html."
   (pcase sxml
-    (`(*RAW-STRING* ,body)
-     `(raw-string ,body))
     (`(*COMMENT* ,body)
      `(comment nil ,body))
     (`(,tag (@ . ,attrs) . ,body)


### PR DESCRIPTION
Hi :wave:

`raw-string` is not working well with `sxml-to-xml` today. For example,

```elisp
(esxml-to-xml '(raw-string "<br>"))
;; => "br"

(sxml-to-xml '(raw-string "<br>"))
;; => "<raw-string>&lt;br&gt;</raw-string>"
```

This PR removes the duplicate `raw-string` handling in `sxml-to-xml`. It worked for my use case, but I'm not sure if it works well for all use cases.

---

Thank you for the great library! I'm making my org-based blog page with `esxml`, following System Crafters. The sxml-based templaet is giving me full control over the output and I'm very happy with the getting result.
