### PR TITLE
Preserve `raw-string` in `sxml-to-esxml`

### DIFF
--- a/esxml.el
+++ b/esxml.el
@@ -224,6 +224,8 @@ See: http://okmij.org/ftp/Scheme/SXML.html. Additionally,
   (pcase sxml
     (`(*RAW-STRING* ,body)
      `(raw-string ,body))
+    (`(raw-string ,body)
+     `(raw-string ,body))
     (`(*COMMENT* ,body)
      `(comment nil ,body))
     (`(,tag (@ . ,attrs) . ,body)


### PR DESCRIPTION
Hi :wave: I'm back..

So here's the real issue:

```elisp
(sxml-to-xml '(*RAW-STRING* "<br>"))
;; => "br"

(sxml-to-xml '(raw-string "<br>"))
;; => "<raw-string>&lt;br&gt;</raw-string>"
```

The fix would be preserving the `raw-string` expression just like done with `*RAW-STRING*`.
